### PR TITLE
Make SmoothDateRangePickerFragment available to Support Fragments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 18 14:27:15 CST 2015
+#Wed Mar 15 15:11:07 WET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 2
         versionName "0.2.0"
     }
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 }
 
 task generateSourcesJar(type: Jar) {

--- a/library/src/main/java/com/leavjenn/smoothdaterangepicker/date/SmoothDateRangePickerFragment.java
+++ b/library/src/main/java/com/leavjenn/smoothdaterangepicker/date/SmoothDateRangePickerFragment.java
@@ -18,12 +18,12 @@ package com.leavjenn.smoothdaterangepicker.date;
 
 import android.animation.ObjectAnimator;
 import android.app.Activity;
-import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
 import android.text.InputType;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -297,7 +297,7 @@ public class SmoothDateRangePickerFragment extends DialogFragment implements OnC
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        Log.d(TAG, "onCreateView: ");
+        //Log.d(TAG, "onCreateView: ");
         getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
         View view = inflater.inflate(R.layout.sdrp_dialog, container);
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.leavjenn.smoothdaterangepicker"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -23,5 +23,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile project (":library")
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 }

--- a/sample/src/main/java/com/leavjenn/smoothdaterangepickerexample/MainActivity.java
+++ b/sample/src/main/java/com/leavjenn/smoothdaterangepickerexample/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
                                         tvDateRange.setText(date);
                                     }
                                 });
-                smoothDateRangePickerFragment.show(getFragmentManager(), "Datepickerdialog");
+                smoothDateRangePickerFragment.show(getSupportFragmentManager(), "Datepickerdialog");
             }
         });
 


### PR DESCRIPTION
SmoothDateRangePickerFragment now extends android.support.v4.app.DialogFragment so it can be used by Fragments from the support library

Update all support libraries, gradle and sdk versions to their latest versions